### PR TITLE
Fix BigDecimal post link to IEEE 754 article

### DIFF
--- a/collections/_posts/2025-12-22-java-bigdecimal-vs-double.md
+++ b/collections/_posts/2025-12-22-java-bigdecimal-vs-double.md
@@ -20,7 +20,7 @@ description: Why BigDecimal exists, how it really works, and when you should rea
 ---
 *This post is part of my [Floating Point Without Tears](https://systemhalted.in/categories/#cat-series-4-floating-point-without-tears) series on how Java numbers misbehave and how to live with them.*
 
-In my earlier post on [IEEE 754 doubles]({% post_url 2025-12-04-ieee-754-doubles/ %}) I showed how a tiny Java example could break your intuition about numbers. The JVM was not being sloppy. It was faithfully following the floating point rules. The surprise came from my mental model, not from the hardware.
+In my earlier post on [IEEE 754 doubles]({% post_url 2025-12-04-ieee-754-doubles %}) I showed how a tiny Java example could break your intuition about numbers. The JVM was not being sloppy. It was faithfully following the floating point rules. The surprise came from my mental model, not from the hardware.
 
 BigDecimal is Java's answer to a different problem: *what if I actually need decimal correctness, not fast binary approximation?* It is the type you reach for when cents matter, reconciliation matters, or auditors matter.
 


### PR DESCRIPTION
## Summary
- fix the IEEE 754 article link in `collections/_posts/2025-12-22-java-bigdecimal-vs-double.md` to use the correct `post_url` syntax
- prevent the Liquid build failure caused by the trailing slash in the `post_url`

## Testing
- bundle exec jekyll build *(fails: `jekyll` executable missing because gems could not be installed; rubygems.org requests returned 403 during `bundle install`)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694abb8a919883238611213b0ae1eeae)