### PR TITLE
Fix masthead title wrapping on mobile

### DIFF
--- a/public/css/site.css
+++ b/public/css/site.css
@@ -625,6 +625,7 @@ h1, h2, h3, h4, h5, h6 {
   color: #313131;
   font-size: 1.6rem;
   font-weight: 800;
+  overflow-wrap: anywhere;
 }
 .masthead-title a {
   color: #b22222;
@@ -641,8 +642,12 @@ h1, h2, h3, h4, h5, h6 {
   .masthead .container {
     padding-left: 4rem;
   }
+  .masthead-title {
+    font-size: 1.4rem;
+  }
   .masthead-title small {
-    display: inline;
+    display: block;
+    margin-left: 0;
   }
 }
 


### PR DESCRIPTION
### Motivation
- The site title was truncated on narrow screens (e.g., iPhone 17 Pro) due to no wrapping and a large font size.
- The masthead also needed room for the sidebar toggle so the tagline could be pushed onto a new line on mobile.
- Improve readability and prevent overflow when very long site titles are used.

### Description
- Updated `public/css/site.css` to add `overflow-wrap: anywhere;` to `.masthead-title` to allow breaking long words. 
- Reduced `.masthead-title` font size inside the `@media (max-width: 48em)` rule to `1.4rem` to avoid truncation on small screens. 
- Changed `.masthead-title small` to `display: block` and removed its left margin on small screens so the tagline stacks beneath the title. 

### Testing
- Attempted `bundle exec jekyll build` to validate the site and it failed with `bundler: command not found: jekyll` in this environment. 
- No automated CSS tests exist; changes were limited to `public/css/site.css` and committed for review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dd7d7fa888323b352cad2cbd74555)