### PR TITLE
Fix masthead spacing on small screens

### DIFF
--- a/public/css/site.css
+++ b/public/css/site.css
@@ -617,7 +617,8 @@ h1, h2, h3, h4, h5, h6 {
 
 /* Override masthead to leave room for the toggle and show full title */
 .masthead .container {
-  padding-left: 4.5rem;
+  padding-left: calc(5.5rem + env(safe-area-inset-left));
+  padding-right: calc(1rem + env(safe-area-inset-right));
 }
 .masthead-title {
   margin-top: 0;
@@ -640,7 +641,8 @@ h1, h2, h3, h4, h5, h6 {
 }
 @media (max-width: 48em) {
   .masthead .container {
-    padding-left: 4rem;
+    padding-left: calc(5rem + env(safe-area-inset-left));
+    padding-right: calc(1rem + env(safe-area-inset-right));
   }
   .masthead-title {
     font-size: 1.4rem;


### PR DESCRIPTION
### Motivation
- Prevent the masthead title from colliding with the hamburger sidebar toggle on narrow viewports and on devices with display cutouts.
- Ensure masthead spacing accounts for device safe-area insets so the site title remains visible and legible.

### Description
- Updated `public/css/site.css` to increase `.masthead .container` left padding to `calc(5.5rem + env(safe-area-inset-left))` and added `padding-right: calc(1rem + env(safe-area-inset-right))`.
- Adjusted the `@media (max-width: 48em)` rule to use `calc(5rem + env(safe-area-inset-left))` and matching right padding for small screens.
- Touched files: `public/css/site.css` (committed with message `Fix masthead spacing`).

### Testing
- Attempted to run `bundle install` and `bundle exec jekyll serve` to verify the change locally, but `bundle install` failed with a `403 Forbidden` error when fetching gems so the local server could not be started.
- No automated tests were executed because the dependency install failed and the build could not be run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ddaaf5f0883239c276c1138881f2c)