### PR TITLE
Make machine-epsilon SVG responsive

### DIFF
--- a/_includes/svg/machine-epsilon-grid.svg
+++ b/_includes/svg/machine-epsilon-grid.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="920" height="380" viewBox="0 0 920 380" role="img" aria-label="Double precision grid spacing near 1.0 vs near 1e16">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 920 380" role="img" aria-label="Double precision grid spacing near 1.0 vs near 1e16" preserveAspectRatio="xMidYMid meet" style="max-width: 100%; height: auto; display: block;">
   <style>
     .title { font: 700 18px system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; fill: #111; }
     .label { font: 13px system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; fill: #222; }


### PR DESCRIPTION
### Motivation
- The machine-epsilon illustration was using fixed SVG sizing and was cropping on narrow viewports such as iPhone, so the goal is to make the graphic scale to its container and preserve its aspect ratio. 
- Ensure embedded SVG in the post does not overflow or get clipped on mobile devices. 

### Description
- Updated `_includes/svg/machine-epsilon-grid.svg` by replacing the fixed `width`/`height` with `width="100%"`, adding `preserveAspectRatio="xMidYMid meet"`, and an inline `style="max-width: 100%; height: auto; display: block;"` to allow responsive scaling. 
- No other content or layout files were modified. 

### Testing
- Served the repository files with `python -m http.server` and captured a mobile (375×667) screenshot of the SVG using Playwright, which produced the mobile screenshot artifact successfully. 
- Attempted to run a local Jekyll build with `bundle exec jekyll serve`, but `bundle install` failed due to a `403 Forbidden` from `rubygems.org`, so a full Jekyll build was not completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f9b0d4b688323a0d326959820b9b2)