### PR TITLE
Fix featured image path for vibe coding post

### DIFF
--- a/collections/_posts/2025-12-15-vibe-coding-and-baby-genius.md
+++ b/collections/_posts/2025-12-15-vibe-coding-and-baby-genius.md
@@ -6,7 +6,7 @@ comments: true
 categories: [Technology, Software Engineering, AI]
 tags: [agentic-workflows, vibe-coding, testing, observability, conventions, testing]
 description: Vibe coding is fun again. However, Agents are still baby geniuses. The fix is turning preferences into accountability.
-featured_image: assets/images/featued/2025-12-15-vibe-coding-and-baby-genius.png
+featured_image: assets/images/featured/2025-12-15-vibe-coding-and-baby-genius.png
 featured_image_alt: A programmer at a multi monitor desk codes beside a cute "baby genius" robot with a pacifier under a neon "Vibe Coding" sign, with charts, a ping pong paddle, and a suitcase hinting at trust, context, and autonomy.
 featured_image_caption:  AI Agents as baby geniuses - brilliant, needy, and not quite ready for ping pong or vacation.
 ---


### PR DESCRIPTION
### Motivation

- The post banner was not showing because the front-matter referenced a misspelled directory (`featued`) that does not match the actual asset path. 
- Correcting the path ensures the featured image resolves against the existing image in `assets/images/featured/`.

### Description

- Updated the `featured_image` front-matter in `collections/_posts/2025-12-15-vibe-coding-and-baby-genius.md` from `assets/images/featued/...` to `assets/images/featured/...`.
- This is a content-only fix and does not change site layout or logic.

### Testing

- No automated tests were run for this content-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950b8990b188323afaa975b81f7a057)