### PR TITLE
Quote featured image front matter to fix YAML parsing for Discipline First post

### DIFF
--- a/collections/_posts/2025-12-31-discipline-first-trust-pipeline-for-ai-assisted-coding.md
+++ b/collections/_posts/2025-12-31-discipline-first-trust-pipeline-for-ai-assisted-coding.md
@@ -20,8 +20,8 @@ tags:
   - guardrails
   - engineering-discipline
 featured_image: assets/images/featured/2025-12-31-discipline-first-trust-pipeline-for-ai-assisted-coding.png
-featured_image_alt: Illustration of a human and an AI collaborating at a laptop beside a colorful pipeline labeled "Brief," "Guardrails," "Tests," and "Ship," each with a checkmark, ending in a rocket launch to represent reliable delivery.
-featured_image_caption: Discipline First: a trust pipeline for AI-assisted coding, where briefs, guardrails, and tests turn speed into shippable software.
+featured_image_alt: 'Illustration of a human and an AI collaborating at a laptop beside a colorful pipeline labeled "Brief," "Guardrails," "Tests," and "Ship," each with a checkmark, ending in a rocket launch to represent reliable delivery.'
+featured_image_caption: 'Discipline First: a trust pipeline for AI-assisted coding, where briefs, guardrails, and tests turn speed into shippable software.'
 description: "AI-assisted coding is a force multiplier. This post argues that disciplined engineering practices, rooted in Extreme Programming, are what make agentic workflows trustworthy and shippable."
 ---
 


### PR DESCRIPTION
### Motivation
- The post's `featured_image_alt` and `featured_image_caption` contained unquoted text with punctuation that caused YAML front-matter parsing errors, which prevented the title/featured image from rendering.  
- Fix the YAML so Jekyll/Liquid can read the front matter reliably and display the post metadata.  

### Description
- Quote the `featured_image_alt` and `featured_image_caption` values in `collections/_posts/2025-12-31-discipline-first-trust-pipeline-for-ai-assisted-coding.md` to make the front matter valid YAML.  
- No other content or layout files were modified.  

### Testing
- Ran a front-matter parse check with Ruby/Psych to confirm the YAML syntax error was resolved, which removed the prior `Psych::SyntaxError` (note: `Psych::DisallowedClass: Date` was observed when using `safe_load` but is unrelated to the quoted strings).  
- Attempted `bundle exec jekyll build --future` to run a full site build, but the environment could not run `jekyll` (`bundler: command not found: jekyll`), so a full build could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954bc885d8883238f74120d3218d656)