### PR TITLE
Update masthead color to blue

### DIFF
--- a/public/css/site.css
+++ b/public/css/site.css
@@ -598,20 +598,21 @@ h1, h2, h3, h4, h5, h6 {
   padding-top:    1rem;
   padding-bottom: 1rem;
   margin-bottom: 3rem;
-  border-bottom: 1px solid #eee;
+  background-color: #1d4ed8;
+  border-bottom: 1px solid #1e40af;
 }
 .masthead-title {
   margin-top: 0;
   margin-bottom: 0;
-  color: #505050;
+  color: #eff6ff;
 }
 .masthead-title a {
-  color: #505050;
+  color: #eff6ff;
 }
 .masthead-title small {
   font-size: 75%;
   font-weight: 400;
-  color: #c0c0c0;
+  color: #bfdbfe;
   letter-spacing: 0;
 }
 
@@ -623,18 +624,18 @@ h1, h2, h3, h4, h5, h6 {
 .masthead-title {
   margin-top: 0;
   margin-bottom: 0;
-  color: #313131;
+  color: #eff6ff;
   font-size: 1.6rem;
   font-weight: 800;
   overflow-wrap: anywhere;
 }
 .masthead-title a {
-  color: #b22222;
+  color: #eff6ff;
 }
 .masthead-title small {
   font-size: 0.95rem;
   font-weight: 600;
-  color: #9ca3af;
+  color: #bfdbfe;
   letter-spacing: 0;
   margin-left: 0.35rem;
   display: inline;


### PR DESCRIPTION
### Motivation
- Make the site masthead visually distinct by switching it to a blue theme for better emphasis. 
- Ensure text and link colors have sufficient contrast against the new background. 

### Description
- Updated `public/css/site.css` to set `.masthead` `background-color: #1d4ed8` and `border-bottom: 1px solid #1e40af`.
- Adjusted `.masthead-title`, `.masthead-title a`, and `.masthead-title small` colors to `#eff6ff` and `#bfdbfe` for improved contrast.
- Applied the color updates both to the base `.masthead` rules and the masthead override block so responsive variants inherit the new colors.

### Testing
- Attempted to run `bundle exec jekyll serve` but it failed because the `jekyll` executable was not available (bundler suggested `bundle install`).
- Ran `bundle install` to fetch gems, which failed due to `rubygems.org` returning a `403 Forbidden`, so no local Jekyll build was completed.
- No automated Jekyll build (`bundle exec jekyll build`) was successfully run due to the gem fetch failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695716eb46388323bf0ed84353902e6a)