### PR TITLE
Increase homepage pagination to 10 posts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ tagline:             'By Palak Mathur'
 description:         'SystemHalted - I am just a DOS error'
 url:                 https://systemhalted.in
 baseurl:             ''
-paginate:            8
+paginate:            10
 permalink:           pretty
 disqus_shortname:    palakmathurgithub
 


### PR DESCRIPTION
### Motivation
- The site homepage was only showing 8 posts per page due to `paginate: 8`, causing the grid to display fewer cards than intended. 
- The intent is to show up to 10 posts per page so the layout can fill two full rows (10 cards) where content is available.

### Description
- Updated the pagination setting by changing `paginate` from `8` to `10` in `_config.yml`.
- This is a config-only change and affects the number of posts output on the homepage and paginated pages generated by Jekyll.
- No other templates, styles, or content files were modified.

### Testing
- No automated tests were run for this config-only change.
- To validate locally, run `bundle exec jekyll build` or `bundle exec jekyll serve` to ensure the site generates the expected number of posts per page.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960152cddfc8323a212734ba3a2c48a)