### PR TITLE
Adjust tablet post grid to two columns

### DIFF
--- a/assets/css/nord.css
+++ b/assets/css/nord.css
@@ -1174,6 +1174,12 @@ body.search-open {
   margin: 1rem 0 2rem;
 }
 
+@media (min-width: 768px) and (max-width: 1024px) {
+  .post-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
 .post-card {
   background: var(--surface);
   border: 1px solid var(--border);


### PR DESCRIPTION
### Motivation
- The existing `.post-grid` uses `repeat(auto-fit, minmax(240px, 1fr))` which produces partially filled rows on iPad-sized viewports (e.g., 4 + 4 + 2 columns). 
- The intent is to ensure the post grid fills rows cleanly for tablet devices and avoids empty columns. 

### Description
- Add a tablet-specific media query `@media (min-width: 768px) and (max-width: 1024px)` that forces the post grid to two columns. 
- Set `.post-grid` to `grid-template-columns: repeat(2, minmax(0, 1fr))` within that media query. 
- Modified file: `assets/css/nord.css` (insertion near the `.post-grid` rule). 

### Testing
- Attempted to run `bundle exec jekyll serve --livereload --host 0.0.0.0 --port 4000`, which failed because the `jekyll` executable is not available in this environment. 
- No `bundle exec jekyll build` was run due to the missing gems/execs in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961279178608323b838a63e9a7fa381)