### PR TITLE
Fix canonical URL tag rendering

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -10,7 +10,7 @@
   <!-- Enable responsiveness on mobile devices -->
   <meta name="viewport" content="width=device-width,initial-scale=1.0,shrink-to-fit=no" />
 
-  {% if page.url and site.baseurl %}
+  {% if page.url %}
   <link rel="canonical" href="{{ page.url | absolute_url }}">
   {% endif %}
 


### PR DESCRIPTION
### Motivation
- Ensure the canonical tag is always emitted when a page has a URL to provide consistent canonicalization for search engines.
- Resolve the previous dependency on `site.baseurl` which could prevent the canonical tag from being rendered.

### Description
- Updated `_includes/head.html` to change the conditional from `{% if page.url and site.baseurl %}` to `{% if page.url %}` so the canonical link is emitted whenever `page.url` exists.
- The canonical `href` continues to use `{{ page.url | absolute_url }}` to produce an absolute URL.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964048065988323984a8fdb9be083b9)