### PR TITLE
Enable KaTeX math rendering: configure kramdown and include KaTeX assets

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,6 +17,8 @@ author:
 
 markdown: kramdown
 highlighter: rouge
+kramdown:
+  math_engine: katex
 # Gems
 plugins:
   - jekyll-paginate

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -50,6 +50,7 @@
   </script>
 
   <link rel="stylesheet" href="{{ '/assets/css/nord.css' | relative_url }}">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css" integrity="sha384-odtC4izYjqA1vZjjkA3TEr7dtwoj0Dbp2u4PjFOE8iFhRfT5nK2DlbZksh6sK05q" crossorigin="anonymous">
   
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Rubik:wght@400;500;600;700;800&family=Source+Code+Pro:wght@400;500;600&family=UnifrakturMaguntia&display=swap">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -61,6 +62,25 @@
   <link rel="shortcut icon" href="{{ '/assets/favicon.ico' | relative_url }}">
 
   <link rel="alternate" type="application/rss+xml" href="{{ '/feed.xml' | relative_url }}">
+
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.js" integrity="sha384-sFz8bA1mcKT5hyS1QvI5S2aXGlJvUZ7iQ9VhM3nlY8vf0bPzY6KrhPzY8k4LsyXC" crossorigin="anonymous"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/contrib/auto-render.min.js" integrity="sha384-EkJ2L0+H6mqwDEnU4DsdZ1kI6Qx1DoP0Z0y2tMHmbG7MPhdwjyE9QBeB6+NQVRD3" crossorigin="anonymous"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      if (typeof renderMathInElement !== 'function') {
+        return;
+      }
+      renderMathInElement(document.body, {
+        delimiters: [
+          { left: '$$', right: '$$', display: true },
+          { left: '$', right: '$', display: false },
+          { left: '\\(', right: '\\)', display: false },
+          { left: '\\[', right: '\\]', display: true }
+        ],
+        throwOnError: false
+      });
+    });
+  </script>
 
   {% if site.google_analytics_id %}
  <!-- Global site tag (gtag.js) - Google Analytics -->

--- a/assets/css/nord.css
+++ b/assets/css/nord.css
@@ -268,6 +268,17 @@ pre code {
   color: inherit;
 }
 
+.katex {
+  font-size: 1em;
+  color: var(--text-strong);
+}
+
+.katex-display {
+  margin: 1.25rem 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
 .highlight,
 .highlighter-rouge {
   font-family: var(--font-mono);


### PR DESCRIPTION
### Motivation
- Ensure LaTeX math inside Markdown is preserved and rendered by setting kramdown's math engine to KaTeX.
- Load KaTeX client-side so inline and display math (`$...$`, `$$...$$`, `\(...\)`, `\[...\]`) render in the browser.
- Keep math visuals consistent with the site's Nord theme and allow wide display equations to scroll.
- Fail gracefully for malformed math to avoid breaking pages.

### Description
- Add `kramdown: math_engine: katex` to `_config.yml` to align Markdown parsing with KaTeX.
- Include KaTeX CSS and deferred JS (`katex.min.js` and `contrib/auto-render.min.js`) in `_includes/head.html` with `integrity` and `crossorigin` attributes.
- Initialize `renderMathInElement` on `DOMContentLoaded` with common delimiters and `throwOnError: false` to auto-render math.
- Add theme-aware styles for `.katex` and `.katex-display` to `assets/css/nord.css` for color and layout consistency.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696415fcaaa483239c4b127faad526fc)